### PR TITLE
Set forest background image for gameplay

### DIFF
--- a/game.py
+++ b/game.py
@@ -132,6 +132,10 @@ AMMO_COLOR = (255, 255, 255)
 
 screen = pygame.display.set_mode((WIDTH, HEIGHT))
 pygame.display.set_caption("Ninja vs Oni")
+background_img = pygame.image.load(
+    os.path.join(ASSET_DIR, "ForestBackground.png")
+).convert()
+background_img = pygame.transform.scale(background_img, (WIDTH, HEIGHT))
 player_idle_img = player_idle_img.convert_alpha()
 player_walk_imgs = [img.convert_alpha() for img in player_walk_imgs]
 enemy_img = enemy_img.convert_alpha()
@@ -344,7 +348,7 @@ def run_game():
             ammo += 1
             ammo_x, ammo_y = None, None
 
-        screen.fill(BACKGROUND_COLOR)
+        screen.blit(background_img, (0, 0))
         score_text = font.render(f"Score: {score}", True, (255, 255, 255))
         screen.blit(score_text, (10, 10))
         # ammo indicator


### PR DESCRIPTION
## Summary
- load `ForestBackground.png` after initializing the display
- scale background to screen size once and draw each frame

## Testing
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_6848848cd4d88323bc3702662dcba036