### PR TITLE
Replace background image with dark green fill

### DIFF
--- a/game.py
+++ b/game.py
@@ -114,11 +114,8 @@ else:
     coin_sound = throw_sound = hit_sound = None
 
 WIDTH, HEIGHT = 800, 600
-BACKGROUND_COLOR = (0, 0, 0)
-background_img = pygame.image.load(
-    os.path.join(ASSET_DIR, "ForestBackground.png")
-).convert()
-background_img = pygame.transform.scale(background_img, (WIDTH, HEIGHT))
+# Use a dark green background instead of an image
+BACKGROUND_COLOR = (0, 100, 0)
 
 player_radius = player_idle_img.get_width() // 2
 player_speed = 5
@@ -136,10 +133,6 @@ AMMO_COLOR = (255, 255, 255)
 
 screen = pygame.display.set_mode((WIDTH, HEIGHT))
 pygame.display.set_caption("Ninja vs Oni")
-background_img = pygame.image.load(
-    os.path.join(ASSET_DIR, "ForestBackground.png")
-).convert()
-background_img = pygame.transform.scale(background_img, (WIDTH, HEIGHT))
 player_idle_img = player_idle_img.convert_alpha()
 player_walk_imgs = [img.convert_alpha() for img in player_walk_imgs]
 enemy_img = enemy_img.convert_alpha()
@@ -352,7 +345,7 @@ def run_game():
             ammo += 1
             ammo_x, ammo_y = None, None
 
-        screen.blit(background_img, (0, 0))
+        screen.fill(BACKGROUND_COLOR)
         score_text = font.render(f"Score: {score}", True, (255, 255, 255))
         screen.blit(score_text, (10, 10))
         # ammo indicator


### PR DESCRIPTION
## Summary
- remove background image loading
- fill screen with a solid dark green color

## Testing
- `pip install pygame`
- `python3 game.py` *(fails: XDG_RUNTIME_DIR invalid and ALSA errors)*

------
https://chatgpt.com/codex/tasks/task_e_68488b8d7e88832393335f132de5db64