### PR TITLE
Fix zombie sprite sheet animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ python3 game.py
 ```
 
 Pygame is required to run the demo.
+
+### Credits
+
+- **Zombie RPG sprites** by Curt (March 20, 2013) from [OpenGameArt](https://opengameart.org)
+- **Block Ninja 2D sprites** by Korba™ (May 28, 2014) from [OpenGameArt](https://opengameart.org)
+

--- a/game.py
+++ b/game.py
@@ -97,7 +97,26 @@ player_walk_imgs = [
     pygame.image.load(os.path.join(ASSET_DIR, "Block Ninja", "walk c.PNG")),
     pygame.image.load(os.path.join(ASSET_DIR, "Block Ninja", "walk d.PNG")),
 ]
-enemy_img = pygame.image.load(os.path.join(ASSET_DIR, "images", "oni.png"))
+# Load zombie sprite sheets for enemies
+zombie_frames_list = []
+zombie_dir = os.path.join(ASSET_DIR, "Zombies", "Zombies")
+directions = ["down", "left", "right", "up"]
+for i in range(1, 7):
+    sheet = pygame.image.load(
+        os.path.join(zombie_dir, f"{i}ZombieSpriteSheet.png")
+    )
+    frame_w = sheet.get_width() // 3
+    frame_h = sheet.get_height() // 4
+    frames_by_dir = {}
+    for row, direction in enumerate(directions):
+        frames = []
+        for col in range(3):
+            rect = pygame.Rect(col * frame_w, row * frame_h, frame_w, frame_h)
+            frames.append(sheet.subsurface(rect))
+        frames_by_dir[direction] = frames
+    zombie_frames_list.append(frames_by_dir)
+
+enemy_img = zombie_frames_list[0]["down"][0]
 coin_img = pygame.image.load(os.path.join(ASSET_DIR, "images", "coin.png"))
 shuriken_img = pygame.image.load(
     os.path.join(ASSET_DIR, "Block Ninja", "shuriken.PNG")
@@ -123,7 +142,7 @@ player_speed = 5
 projectile_radius = shuriken_img.get_width() // 2
 projectile_speed = 10
 
-enemy_size = enemy_img.get_width()
+enemy_size = max(enemy_img.get_width(), enemy_img.get_height())
 enemy_speed = 3
 coin_size = coin_img.get_width()
 coin_speed = 4
@@ -132,10 +151,16 @@ coin_speed = 4
 AMMO_COLOR = (255, 255, 255)
 
 screen = pygame.display.set_mode((WIDTH, HEIGHT))
-pygame.display.set_caption("Ninja vs Oni")
+pygame.display.set_caption("Ninja vs Zombies")
 player_idle_img = player_idle_img.convert_alpha()
 player_walk_imgs = [img.convert_alpha() for img in player_walk_imgs]
-enemy_img = enemy_img.convert_alpha()
+zombie_frames_list = [
+    {
+        direction: [frame.convert_alpha() for frame in frames]
+        for direction, frames in sheet.items()
+    }
+    for sheet in zombie_frames_list
+]
 coin_img = coin_img.convert_alpha()
 shuriken_img = shuriken_img.convert_alpha()
 clock = pygame.time.Clock()
@@ -167,7 +192,7 @@ def spawn_enemy():
         x = -enemy_size
         y = random.randint(0, HEIGHT - enemy_size)
         dx, dy = enemy_speed, 0
-    return x, y, dx, dy
+    return x, y, dx, dy, direction
 
 
 def spawn_coin():
@@ -207,7 +232,11 @@ def run_game():
     player_anim_timer = 0
     current_img = player_idle_img
 
-    enemy_x, enemy_y, enemy_dx, enemy_dy = spawn_enemy()
+    enemy_x, enemy_y, enemy_dx, enemy_dy, enemy_direction = spawn_enemy()
+    sheet = random.choice(zombie_frames_list)
+    enemy_frames = sheet[enemy_direction]
+    enemy_anim_index = 0
+    enemy_anim_timer = 0
     enemy_spawn_count = 1
 
     coin_x, coin_y, coin_dx, coin_dy = spawn_coin()
@@ -275,6 +304,11 @@ def run_game():
         player_x = max(player_radius, min(WIDTH - player_radius, player_x))
         player_y = max(player_radius, min(HEIGHT - player_radius, player_y))
 
+        enemy_anim_timer += 1
+        if enemy_anim_timer >= 10:
+            enemy_anim_timer = 0
+            enemy_anim_index = (enemy_anim_index + 1) % len(enemy_frames)
+
         enemy_x += enemy_dx
         enemy_y += enemy_dy
         if (
@@ -283,7 +317,11 @@ def run_game():
             or enemy_y < -enemy_size
             or enemy_y > HEIGHT
         ):
-            enemy_x, enemy_y, enemy_dx, enemy_dy = spawn_enemy()
+            enemy_x, enemy_y, enemy_dx, enemy_dy, enemy_direction = spawn_enemy()
+            sheet = random.choice(zombie_frames_list)
+            enemy_frames = sheet[enemy_direction]
+            enemy_anim_index = 0
+            enemy_anim_timer = 0
             enemy_spawn_count += 1
             if enemy_spawn_count % 4 == 0 and ammo_x is None:
                 ammo_x, ammo_y = spawn_ammo()
@@ -315,7 +353,11 @@ def run_game():
                 score += 1
                 if hit_sound:
                     hit_sound.play()
-                enemy_x, enemy_y, enemy_dx, enemy_dy = spawn_enemy()
+                enemy_x, enemy_y, enemy_dx, enemy_dy, enemy_direction = spawn_enemy()
+                sheet = random.choice(zombie_frames_list)
+                enemy_frames = sheet[enemy_direction]
+                enemy_anim_index = 0
+                enemy_anim_timer = 0
                 enemy_spawn_count += 1
                 if enemy_spawn_count % 4 == 0 and ammo_x is None:
                     ammo_x, ammo_y = spawn_ammo()
@@ -354,7 +396,7 @@ def run_game():
         screen.blit(ammo_text, (25, 40))
 
         screen.blit(current_img, current_img.get_rect(center=(player_x, player_y)))
-        screen.blit(enemy_img, (enemy_x, enemy_y))
+        screen.blit(enemy_frames[enemy_anim_index], (enemy_x, enemy_y))
         screen.blit(coin_img, (coin_x, coin_y))
         if ammo_x is not None:
             screen.blit(shuriken_img, shuriken_img.get_rect(center=(ammo_x, ammo_y)))


### PR DESCRIPTION
## Summary
- load zombie frames by direction (3x4 sheets)
- random zombie sheet and direction-aware animation on spawn

## Testing
- `python3 -m py_compile game.py`
- `python3 game.py` *(launched and interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684894fb42048323a3029cda73cb7527