### PR TITLE
Fix zombie animation frames

### DIFF
--- a/game.py
+++ b/game.py
@@ -90,9 +90,11 @@ class Zombie(pygame.sprite.Sprite):
     def __init__(self, spritesheet_path):
         super().__init__()
         self.sprite_sheet = pygame.image.load(spritesheet_path).convert_alpha()
-        self.frame_width = 32
-        self.frame_height = 32
+        # Determine frame dimensions from the sheet itself (3 columns x 4 rows)
+        sheet_w, sheet_h = self.sprite_sheet.get_size()
         self.frames_per_direction = 3
+        self.frame_width = sheet_w // self.frames_per_direction
+        self.frame_height = sheet_h // 4
         self.directions = {
             "down": 0,
             "left": 1,
@@ -148,7 +150,7 @@ player_walk_imgs = [
     pygame.image.load(os.path.join(ASSET_DIR, "Block Ninja", "walk c.PNG")),
     pygame.image.load(os.path.join(ASSET_DIR, "Block Ninja", "walk d.PNG")),
 ]
-# Zombie sprite sheets (3 columns by 4 rows of 32x32 frames)
+# Zombie sprite sheets (3 columns x 4 rows)
 zombie_sheet_paths = [
     os.path.join(ASSET_DIR, "Zombies", "Zombies", f"{i}ZombieSpriteSheet.png")
     for i in range(1, 7)
@@ -178,8 +180,11 @@ player_speed = 5
 projectile_radius = shuriken_img.get_width() // 2
 projectile_speed = 10
 
-# Each zombie frame is 32x32
-enemy_size = 32
+# Determine enemy sprite size from a sample zombie sheet
+sample_sheet = pygame.image.load(zombie_sheet_paths[0])
+enemy_frame_w = sample_sheet.get_width() // 3
+enemy_frame_h = sample_sheet.get_height() // 4
+enemy_size = max(enemy_frame_w, enemy_frame_h)
 enemy_speed = 3
 coin_size = coin_img.get_width()
 coin_speed = 4


### PR DESCRIPTION
## Summary
- compute zombie frame size from spritesheet
- adjust enemy collision size using those dimensions
- update sprite sheet comment

## Testing
- `python3 -m py_compile game.py`
- `timeout 3 python3 game.py` *(fails: XDG_RUNTIME_DIR audio errors, but game starts then ends)*

------
https://chatgpt.com/codex/tasks/task_e_68489bedfdc08323b19b16cac1539c4e