### PR TITLE
Improve sound loading robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ with `R` or quit with `Q`.
 Binary image and audio files aren't stored in this repository. When the game
 first runs it generates simple CC0 placeholder graphics and sound effects inside
 the `assets/` directory. You can drop in higher quality CC0 replacements.
-Multiple sound variations are supported:
+Place any number of `*.wav` files anywhere inside `assets/sounds/` and the game
+will load them automatically (searching subfolders and ignoring case):
 
-- `hit1.wav`&ndash;`hit5.wav` for enemy hits or when the player is hurt
-- `coin1.wav`&ndash;`coin9.wav` for collecting coins
-- `swish1.wav`&ndash;`swish13.wav` for projectile throws
-- `komiku-it.wav` as looping background music
+- files starting with `hit` play when zombies or the player are struck
+- files starting with `coin` play when coins are collected
+- files starting with `swish` play when throwing projectiles
+- `komiku-it.wav` loops as background music if present
 
 Suggested sources:
 

--- a/game.py
+++ b/game.py
@@ -183,20 +183,48 @@ shuriken_img = pygame.image.load(
 
 # Load sounds
 if pygame.mixer.get_init():
-    coin_sounds = [
-        pygame.mixer.Sound(os.path.join(ASSET_DIR, "sounds", f"coin{i}.wav"))
-        for i in range(1, 10)
-    ]
-    swish_sounds = [
-        pygame.mixer.Sound(os.path.join(ASSET_DIR, "sounds", f"swish{i}.wav"))
-        for i in range(1, 14)
-    ]
-    hit_sounds = [
-        pygame.mixer.Sound(os.path.join(ASSET_DIR, "sounds", f"hit{i}.wav"))
-        for i in range(1, 6)
-    ]
-    pygame.mixer.music.load(os.path.join(ASSET_DIR, "sounds", "komiku-it.wav"))
-    pygame.mixer.music.play(-1)
+    sound_dir = os.path.join(ASSET_DIR, "sounds")
+
+    def load_sound_variations(prefix):
+        """Return a list of pygame Sound objects for files beginning with prefix.
+
+        The search is case-insensitive and recursive so sounds can live in
+        subfolders inside the sounds directory. Any file whose name starts with
+        the prefix and ends with ``.wav`` will be loaded if possible.
+        """
+
+        variations = []
+        lower_prefix = prefix.lower()
+        for root_dir, _dirs, files in os.walk(sound_dir):
+            for name in files:
+                filename = name.lower()
+                if filename.startswith(lower_prefix) and filename.endswith(".wav"):
+                    path = os.path.join(root_dir, name)
+                    try:
+                        variations.append(pygame.mixer.Sound(path))
+                    except pygame.error:
+                        print(f"Failed to load sound '{path}'")
+        return variations
+
+    coin_sounds = load_sound_variations("coin")
+    swish_sounds = load_sound_variations("swish")
+    hit_sounds = load_sound_variations("hit")
+
+    bg_path = None
+    for root_dir, _dirs, files in os.walk(sound_dir):
+        for name in files:
+            if name.lower() == "komiku-it.wav":
+                bg_path = os.path.join(root_dir, name)
+                break
+        if bg_path:
+            break
+
+    if bg_path and os.path.exists(bg_path):
+        try:
+            pygame.mixer.music.load(bg_path)
+            pygame.mixer.music.play(-1)
+        except pygame.error:
+            print(f"Failed to load background music '{bg_path}'")
 else:
     coin_sounds = swish_sounds = hit_sounds = []
 


### PR DESCRIPTION
## Summary
- search `assets/sounds/` recursively and case-insensitively for WAV files
- start background music if `komiku-it.wav` is found anywhere under `assets/sounds`
- clarify README instructions that sounds in subfolders are loaded automatically

## Testing
- `python3 -m py_compile game.py`
- `SDL_VIDEODRIVER=dummy python3 game.py` *(fails: Unknown PCM default)*


------
https://chatgpt.com/codex/tasks/task_e_6848b41f2bb083238a01a79836f9643b