### PR TITLE
Fix background surface reference

### DIFF
--- a/game.py
+++ b/game.py
@@ -610,7 +610,9 @@ def pause_menu():
 
 
 def run_level(level_num, enemy_speed, coin_speed, enemy_count, ammo_interval, coin_delay):
-    global master_volume, sfx_volume, music_volume, score, lives, next_life_score
+    global master_volume, sfx_volume, music_volume
+    global score, lives, next_life_score
+    global selected_background, unlocked_backgrounds, BACKGROUND_SURFACE
     if pygame.mixer.get_init() and not pygame.mixer.music.get_busy():
         start_music()
 


### PR DESCRIPTION
## Summary
- fix global reference for BACKGROUND_SURFACE during level changes

## Testing
- `python -m py_compile game.py`
- `SDL_VIDEODRIVER=dummy timeout 5s python game.py` *(fails: audio disabled but no crash)*

------
https://chatgpt.com/codex/tasks/task_e_6848dff4414c8323a26d47bae84be81d