### PR TITLE
Fix decoration folder mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ first runs it generates simple CC0 placeholder graphics and sound effects inside
 the `assets/` directory. You can drop in higher quality CC0 replacements.
 Place any number of `*.wav`, `*.ogg` or `*.mp3` files anywhere inside
 `assets/sounds/` and the game will load them automatically. Decoration images
-placed in `assets/Decoration` will also be loaded. Files named
-`Blue Flame Flower.png`, `Butterfly.png` or `Fox Bush.png` are treated as
-animated spritesheets.
+placed in `assets/Decorations` will also be loaded. `Butterfly.png` should be
+arranged in quadrants and is treated as an animated spritesheet. It's currently
+the only decoration used by the game.
 
 - files starting with `hit` play when zombies or the player are struck
 - files starting with `coin` play when coins are collected

--- a/game.py
+++ b/game.py
@@ -377,14 +377,15 @@ BACKGROUND_TILES = sorted(
 )
 
 # Decorative images placed randomly in each level
-DECORATION_DIR = os.path.join(ASSET_DIR, "Decoration")
+DECORATION_DIR = os.path.join(ASSET_DIR, "Decorations")
 DECORATION_MAX_SIZE = 48
 DECORATION_IMAGES = []  # Static decorations
 # Animated decorations are stored as lists of frames extracted from a
 # single image arranged in quadrants (top-left, top-right, bottom-left,
 # bottom-right). Only specific files are treated as animated decorations.
 DECORATION_ANIMATIONS = []
-ANIMATED_FILES = {"Blue Flame Flower.png", "Fox Bush.png", "Butterfly.png"}
+# Currently only the butterfly spritesheet is included.
+ANIMATED_FILES = {"Butterfly.png"}
 if os.path.isdir(DECORATION_DIR):
     for f in os.listdir(DECORATION_DIR):
         if not f.lower().endswith(".png"):


### PR DESCRIPTION
## Summary
- point DECORATION_DIR to `assets/Decorations`
- drop unused flower/bush animation entries
- document the butterfly as the sole decoration

## Testing
- `python3 -m py_compile game.py`

------
https://chatgpt.com/codex/tasks/task_e_68490c103ea48323a1be7c820d4795c3